### PR TITLE
Changes to .classpath and OperaWebElement

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,6 +9,6 @@
 	<classpathentry kind="lib" path="lib/commons-io-2.0.1.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/guava-r09.jar"/>
-	<classpathentry kind="lib" path="lib/selenium-java-2.4.0.jar"/>
+	<classpathentry kind="lib" path="lib/selenium-java-2.5.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -9,6 +9,6 @@
 	<classpathentry kind="lib" path="lib/commons-io-2.0.1.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/guava-r09.jar"/>
-	<classpathentry kind="lib" path="lib/selenium-java-2.5.0.jar"/>
+	<classpathentry kind="lib" path="lib/selenium-java-2.4.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/com/opera/core/systems/OperaWebElement.java
+++ b/src/com/opera/core/systems/OperaWebElement.java
@@ -277,9 +277,12 @@ public class OperaWebElement extends RemoteWebElement {
     return isDisplayed();
   }
 
-  public void clear() {
-    executeMethod("return " + OperaAtoms.CLEAR.getValue() + "(locator)");
-  }
+	public void clear() {
+		if (isEnabled()) {
+			if(!Boolean.valueOf(getAttribute("readonly")))
+			executeMethod("return " + OperaAtoms.CLEAR.getValue() + "(locator)");
+		}
+	}
 
   public void sendKeys(CharSequence... keysToSend) {
     // A list of keys that should be held down, instead of pressed


### PR DESCRIPTION
selenium version bumped to 2.5

Clear() should clear only editable and enabled elements 
