### PR TITLE
getAttribute("value") by option element is not work.

### DIFF
--- a/src/com/opera/core/systems/OperaWebElement.java
+++ b/src/com/opera/core/systems/OperaWebElement.java
@@ -220,7 +220,7 @@ public class OperaWebElement extends RemoteWebElement {
     throwIfStale();
 
     if (attribute.toLowerCase().equals("value")) {
-      return callMethod("if(/^input|select|textarea$/i.test(locator.nodeName)){" +
+      return callMethod("if(/^input|select|option|textarea$/i.test(locator.nodeName)){" +
                         "return locator.value;" +
                         "}" +
                         "return locator.textContent;");
@@ -248,7 +248,7 @@ public class OperaWebElement extends RemoteWebElement {
    * @deprecated Use {@link #getAttribute('value')} instead
    */
   public String getValue() {
-    return callMethod("if(/^input|select|textarea$/i.test(locator.nodeName)){" +
+    return callMethod("if(/^input|select|option|textarea$/i.test(locator.nodeName)){" +
                       "return locator.value;" +
                       "}" +
                       "return locator.textContent;");


### PR DESCRIPTION
Hi.

Call optionElement.getAttribute("value") returned "textContent".

You should include the "option" tag in a regular expression.

Sorry in mean English.

thanks.
