### PR TITLE
Escape quotes in javascript parameters

### DIFF
--- a/src/com/opera/core/systems/scope/AbstractEcmascriptService.java
+++ b/src/com/opera/core/systems/scope/AbstractEcmascriptService.java
@@ -133,7 +133,7 @@ public abstract class AbstractEcmascriptService extends AbstractService
       elements.add((WebElement) object);
       builder.append(String.valueOf(object));
     } else if (object instanceof String) {
-      builder.append("'").append(String.valueOf(object)).append("'");
+      builder.append("'").append(escapeQuotes(String.valueOf(object))).append("'");
     } else if (object instanceof Integer || object instanceof Long
                || object instanceof Boolean || object instanceof Float
                || object instanceof Double) {
@@ -141,6 +141,10 @@ public abstract class AbstractEcmascriptService extends AbstractService
     } else {
       throw new IllegalArgumentException("The argument type is not supported");
     }
+  }
+
+  private String escapeQuotes(String s) {
+    return s.replace("'", "\\'");
   }
 
   public String executeJavascript(String using) {


### PR DESCRIPTION
Unescaped quotes in parameters in a javascript call causes the current test to fail with a ecmascript-debugger exception (which is bearable, although not ideal) but also causes all subsequent tests to fail because the browser is no longer connected (which is fatal). This patch addresses the basic issue of ensuring that all strings are properly escaped so they don't trigger this fatal error.

It would be nice to also fix the fatal error that's causing the exception to make all subsequent tests fail, but I'm out of time this weekend for this.
