### PR TITLE
WebElement frames proxied by PageFactory cause ClassCastException

### DIFF
--- a/src/com/opera/core/systems/OperaDriver.java
+++ b/src/com/opera/core/systems/OperaDriver.java
@@ -58,6 +58,7 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.WrapsElement;
 import org.openqa.selenium.logging.Logs;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteLogs;
@@ -805,6 +806,10 @@ public class OperaDriver extends RemoteWebDriver implements TakesScreenshot {
     // TODO: Implement need to find a way to link an element to a runtime
     public WebDriver frame(WebElement frameElement) {
       String script = "return " + OperaAtoms.GET_FRAME_INDEX + "(locator)";
+      // PageObject fields are wrapped by PageFactory
+      while (frameElement instanceof WrapsElement) {
+        frameElement = ((WrapsElement) frameElement).getWrappedElement();
+      }
       Long frameIndex =
           (Long) debugger.callFunctionOnObject(script,
                                                ((OperaWebElement) frameElement).getObjectId(),

--- a/test/com/opera/core/systems/IFramesTest.java
+++ b/test/com/opera/core/systems/IFramesTest.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2011-2012 Opera Software ASA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.opera.core.systems;
+
+import com.opera.core.systems.pages.IFramePage;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.support.PageFactory;
+
+import static org.junit.Assert.assertNotNull;
+
+public class IFramesTest extends OperaDriverTestCase {
+  IFramePage iFramePage;
+  @Before
+  public void bindPage() {
+    getFixture("iframes.html");
+    iFramePage = PageFactory.initElements(driver, IFramePage.class);
+    iFramePage.driver = driver;
+  }
+
+  @Test
+  public void testIFrameFocus() {
+    assertNotNull(iFramePage.getIFrame());
+    iFramePage.leaveIFrame();
+  }
+}

--- a/test/com/opera/core/systems/pages/IFramePage.java
+++ b/test/com/opera/core/systems/pages/IFramePage.java
@@ -1,0 +1,37 @@
+/*
+Copyright 2011-2012 Opera Software ASA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.opera.core.systems.pages;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class IFramePage {
+  public WebDriver driver;
+
+  @FindBy(name = "the-iframe")
+  WebElement iFrame;
+
+  public WebElement getIFrame() {
+    driver.switchTo().frame(iFrame);
+    return driver.switchTo().activeElement();
+  }
+
+  public void leaveIFrame() {
+    driver.switchTo().defaultContent();
+  }
+}

--- a/test/fixtures/iframes.html
+++ b/test/fixtures/iframes.html
@@ -1,0 +1,11 @@
+<!doctype HTML>
+<html>
+<head>
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <title>IFrames fixture</title>
+</head>
+<body>
+  <iframe name="the-iframe">This is the iframe</iframe>
+  <p>This is outside the iframe</p>
+</body>
+</html>


### PR DESCRIPTION
If OperaDriver is used with a PageObject that is created via PageFactory, all WebElements in that object are wrapped in proxies. This can cause ClassCastExceptions inside OperaDriver.frame(WebElement), as that assumes that it is always given an OperaWebElement. This changeset fixes that, and adds a test case to verify it.
