### PR TITLE
executeScript changes driver's execution context, breaking any test that involves .switchTo().frame(...)

### DIFF
--- a/test/com/opera/core/systems/FramesTest.java
+++ b/test/com/opera/core/systems/FramesTest.java
@@ -21,6 +21,7 @@ import com.opera.core.systems.testing.OperaDriverTestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -60,6 +61,20 @@ public class FramesTest extends OperaDriverTestCase {
   public void switchByIndex2() {
     driver.switchTo().frame(2);
     assertNotNull(driver.findElement(By.id(("img_container"))));
+  }
+
+  @Test
+  public void switchToFrameAndExecuteScript() {
+    driver.switchTo().defaultContent();
+    driver.switchTo().frame("a");
+    // Bug: The following JavaScript code causes a switch to the top-level frame
+    String reportedFrameWindowName = ((JavascriptExecutor) driver).executeScript("return window.name;").toString();
+    // Consequently, the following call will fail, unless the frame is switched back using
+    //   driver.switchTo().defaultContent();
+    //   driver.switchTo().frame("a");
+    assertNotNull(driver.findElement(By.id("one")));
+
+    assertEquals("a", reportedFrameWindowName);
   }
 
 }


### PR DESCRIPTION
Steps to reproduce:
1. Switch to a subframe using `driver.switchTo().frame("a")`
2. Cast the driver to a JavascriptExecutor, and call the executeScript
   method.
3. Observe that the called function runs in the context of the top-level
   document instead of the frame identified by "a".
4. Further, observe that any calls to findElement operate on the wrong
   context.

These steps have been implemented in a test case, that offers a potential fix (in the comments) for _users_ of the OperaDriver who need to circumvent this bug.

Summarized: Calling `executeScript()` changes the frame context to _top.

Here's an excerpt of the log file:

```
  <testcase classname="com.opera.core.systems.FramesTest" name="switchToFrameAndExecuteScript" time="0.432">
    <failure message="expected:&lt;[a]&gt; but was:&lt;[]&gt;" type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError: expected:&lt;[a]&gt; but was:&lt;[]&gt;
        at com.opera.core.systems.FramesTest.switchToFrameAndExecuteScript(FramesTest.java:77)
        at com.opera.core.systems.testing.TestRunner.runChild(TestRunner.java:113)
        at com.opera.core.systems.testing.TestRunner.runChild(TestRunner.java:47)
</failure>
  </testcase>
```
