### PR TITLE
Implement support of HTTPS host and SOCKS host/credentials proxy settings

### DIFF
--- a/src/com/opera/core/systems/OperaProxy.java
+++ b/src/com/opera/core/systems/OperaProxy.java
@@ -305,15 +305,23 @@ public class OperaProxy {
         }
         setUsePAC(false);
 
-        // TODO(andreastt): HTTPS proxy
-        // TODO(andreastt): SOCKS proxy
-
         if (proxy.getHttpProxy() != null) {
           setHttpProxy(proxy.getHttpProxy());
         }
         if (proxy.getFtpProxy() != null) {
           setFtpProxy(proxy.getFtpProxy());
         }
+        if (proxy.getSslProxy() != null) {
+          setHttpsProxy(proxy.getSslProxy());
+        }
+        if (proxy.getSocksProxy() != null) {
+          setSocksProxy(proxy.getSocksProxy());
+          if ((proxy.getSocksUsername() != null) && (proxy.getSocksPassword() != null)) {
+            setSocksUsername(proxy.getSocksUsername());
+            setSocksPassword(proxy.getSocksPassword());
+          }
+        }
+        // setup of bypass proxy addresses (noProxy) is not implemented
 
         break;
 


### PR DESCRIPTION
Implement support of HTTPS and SOCKS proxy settings.

If SOCKS proxy and credentials are set up then they are set too.
