### PR TITLE
Ignore opacity on figuring out visibility of the element

### DIFF
--- a/src/com/opera/core/systems/OperaWebElement.java
+++ b/src/com/opera/core/systems/OperaWebElement.java
@@ -178,7 +178,7 @@ public class OperaWebElement extends RemoteWebElement implements CapturesScreen 
 
   public boolean isDisplayed() {
     assertElementNotStale();
-    return (Boolean) evaluateMethod("return " + OperaAtom.IS_DISPLAYED + "(locator)");
+    return (Boolean) evaluateMethod("return " + OperaAtom.IS_DISPLAYED + "(locator, /*ignoreOpacity=*/true)");
   }
 
   public boolean isEnabled() {


### PR DESCRIPTION
Other browsers ignored it, but Opera didn't.
